### PR TITLE
Use rtm.connect

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -267,7 +267,7 @@ def request_channel_name(channel_id):
 
 # Connects to Slacks and initiates socket handshake
 def start_rtm():
-    r = requests.get("https://slack.com/api/rtm.start?token="+TOKEN)
+    r = requests.get("https://slack.com/api/rtm.connect?token="+TOKEN)
     r = r.json()
     # logging.debug(r)
     r = r["url"]


### PR DESCRIPTION
rtm.start is deprecated according to https://api.slack.com/methods/rtm.start
Replace it with rtm.connect https://api.slack.com/methods/rtm.connect